### PR TITLE
replace '-' in parameter by '_'

### DIFF
--- a/lepo/utils.py
+++ b/lepo/utils.py
@@ -17,7 +17,7 @@ def maybe_resolve(object, resolve):
 
 
 def snake_case(string):
-    return camel_case_to_spaces(string).replace(' ', '_')
+    return camel_case_to_spaces(string).replace('-', '_').replace(' ', '_').replace('__', '_')
 
 
 def match_content_type(content_type, content_type_mapping):


### PR DESCRIPTION
When endpoint has some parameter with '-' in name,
it is not translated. So from 'X-Correlation-Id' header
is created 'x-_correlation-_id' variable.
This change makes it 'x_correlation_id'.